### PR TITLE
Use 'default', not 'initial', for browser compatibility.

### DIFF
--- a/src/angular-img-cropper.js
+++ b/src/angular-img-cropper.js
@@ -1147,7 +1147,7 @@ angular.module('angular-img-cropper', []).directive("imageCropper", ['$document'
                             didDraw = didDraw || this.drawCornerCursor(this.markers[i], cropTouch.x, cropTouch.y, e);
                         }
                         if (!didDraw) {
-                            imageCropperDataShare.setStyle(this.canvas, 'initial');
+                            imageCropperDataShare.setStyle(this.canvas, 'default');
                         }
                     }
                     if (!didDraw && !cursorDrawn && this.center.touchInBounds(cropTouch.x, cropTouch.y)) {


### PR DESCRIPTION
Internet Explorer does not support 'initial' for the cursor.
