### PR TITLE
Updated event registration to fix no scrolling on mobile and event registration failure if jQuery not loaded.

### DIFF
--- a/src/angular-img-cropper.js
+++ b/src/angular-img-cropper.js
@@ -380,17 +380,26 @@ angular.module('angular-img-cropper', []).directive("imageCropper", ['$document'
                     this.croppedImage = new Image();
                     this.currentlyInteracting = false;
 
-                    angular.element(window)
-                      .off('mousemove.angular-img-cropper mouseup.angular-img-cropper')
-                      .on('mousemove.angular-img-cropper', this.onMouseMove.bind(this))
-                      .on('mouseup.angular-img-cropper', this.onMouseUp.bind(this));
+                    if (window.jQuery) {
+                        angular.element(window)
+                          .off('mousemove.angular-img-cropper mouseup.angular-img-cropper')
+                          .on('mousemove.angular-img-cropper', this.onMouseMove.bind(this))
+                          .on('mouseup.angular-img-cropper', this.onMouseUp.bind(this));
 
-                    angular.element(canvas)
-                      .off('mousedown.angular-img-cropper touchstart.angular-img-cropper  touchmove.angular-img-cropper touchend.angular-img-cropper')
-                      .on('mousedown.angular-img-cropper', this.onMouseDown.bind(this))
-                      .on('touchstart.angular-img-cropper', this.onTouchStart.bind(this))
-                      .on('touchmove.angular-img-cropper', this.onTouchMove.bind(this))
-                      .on('touchend.angular-img-cropper', this.onTouchEnd.bind(this));
+                        angular.element(canvas)
+                          .off('mousedown.angular-img-cropper touchstart.angular-img-cropper  touchmove.angular-img-cropper touchend.angular-img-cropper')
+                          .on('mousedown.angular-img-cropper', this.onMouseDown.bind(this))
+                          .on('touchstart.angular-img-cropper', this.onTouchStart.bind(this))
+                          .on('touchmove.angular-img-cropper', this.onTouchMove.bind(this))
+                          .on('touchend.angular-img-cropper', this.onTouchEnd.bind(this));
+                    } else {
+                        window.addEventListener('mousemove', this.onMouseMove.bind(this));
+                        window.addEventListener('mouseup', this.onMouseUp.bind(this));
+                        canvas.addEventListener('mousedown', this.onMouseDown.bind(this));
+                        canvas.addEventListener('touchmove', this.onTouchMove.bind(this), false);
+                        canvas.addEventListener('touchstart', this.onTouchStart.bind(this), false);
+                        canvas.addEventListener('touchend', this.onTouchEnd.bind(this), false);
+                    }
                 }
 
                 ImageCropper.prototype.resizeCanvas = function (width, height) {

--- a/src/angular-img-cropper.js
+++ b/src/angular-img-cropper.js
@@ -381,16 +381,16 @@ angular.module('angular-img-cropper', []).directive("imageCropper", ['$document'
                     this.currentlyInteracting = false;
 
                     angular.element(window)
-                      .off('mousemove.angular-img-cropper mouseup.angular-img-cropper touchmove.angular-img-cropper touchend.angular-img-cropper')
+                      .off('mousemove.angular-img-cropper mouseup.angular-img-cropper')
                       .on('mousemove.angular-img-cropper', this.onMouseMove.bind(this))
-                      .on('mouseup.angular-img-cropper', this.onMouseUp.bind(this))
-                      .on('touchmove.angular-img-cropper', this.onTouchMove.bind(this))
-                      .on('touchend.angular-img-cropper', this.onTouchEnd.bind(this));
+                      .on('mouseup.angular-img-cropper', this.onMouseUp.bind(this));
 
                     angular.element(canvas)
-                      .off('mousedown.angular-img-cropper touchstart.angular-img-cropper')
+                      .off('mousedown.angular-img-cropper touchstart.angular-img-cropper  touchmove.angular-img-cropper touchend.angular-img-cropper')
                       .on('mousedown.angular-img-cropper', this.onMouseDown.bind(this))
-                      .on('touchstart.angular-img-cropper', this.onTouchStart.bind(this));
+                      .on('touchstart.angular-img-cropper', this.onTouchStart.bind(this))
+                      .on('touchmove.angular-img-cropper', this.onTouchMove.bind(this))
+                      .on('touchend.angular-img-cropper', this.onTouchEnd.bind(this));
                 }
 
                 ImageCropper.prototype.resizeCanvas = function (width, height) {


### PR DESCRIPTION
Fixing two issues related to event registration.  
1. Events were not being registered if full jQuery not loaded.  Added check to use addEventListener if jQuery not loaded.  Note that along with this change I've found that pull request #32 is also required for touch events to work.
2.  On mobile once an image was loaded the whole page could no longer be scrolled. Moved touchmove and touchend events from window to canvas.
